### PR TITLE
Add Bluetooth 4.0 Low Energy (BLE)

### DIFF
--- a/protou.mk
+++ b/protou.mk
@@ -78,6 +78,7 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.sip.voip.xml:system/etc/permissions/android.software.sip.voip.xml \
     frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml \
     frameworks/native/data/etc/android.hardware.usb.accessory.xml:system/etc/permissions/android.hardware.usb.accessory.xml
+    frameworks/native/data/etc/android.hardware.bluetooth_le.xml:system/etc/permissions/android.hardware.bluetooth_le.xml
 
 # Set usb type
 ADDITIONAL_DEFAULT_PROPERTIES += \


### PR DESCRIPTION
I can't test this, since i don't know how to compile the whole thing - but manually creating the file "system/etc/permissions/android.hardware.bluetooth_le.xml" allows me to use my BLE heart rate monitor (Polar H7) with my protou.
